### PR TITLE
Import mean from StatsBase

### DIFF
--- a/src/CircStats.jl
+++ b/src/CircStats.jl
@@ -11,6 +11,8 @@ using Printf
 
 import Distributions
 
+import StatsBase: mean
+
 export
     # Summary stats
     cdist,


### PR DESCRIPTION
Hi! `estimate_kappa_vonMises` failed for me on Julia 1.5 and 1.6 missing the `mean` function, so I just imported it from StatsBase