### PR TITLE
Add "url" in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with calls to methods elsewhere (as in the case of `von_mises_cdf`).
 On Julia v0.7 and above:
 
 ```julia
-julia> import Pkg; Pkg.add("https://github.com/anowacki/CircStats.jl")
+julia> import Pkg; Pkg.add(url="https://github.com/anowacki/CircStats.jl")
 ```
 
 On older versions:

--- a/src/CircStats.jl
+++ b/src/CircStats.jl
@@ -11,6 +11,8 @@ using Printf
 
 import Distributions
 
+import StatsBase: mean
+
 export
     # Summary stats
     cdist,


### PR DESCRIPTION
The current install instructions failed for me on 1.5 and 1.6.

Adding "url=" in `Pkg.add` fixes it.